### PR TITLE
fixed typo copying wrong map

### DIFF
--- a/src/main/java/gov/nih/ncats/molwitch/renderer/ColorPalette.java
+++ b/src/main/java/gov/nih/ncats/molwitch/renderer/ColorPalette.java
@@ -110,7 +110,7 @@ public class ColorPalette {
             for(Map.Entry<String, ARGBColor> e: atomColors.entrySet()){
                 atomMap.put(e.getKey(), e.getValue().asHex());
             }
-            map.put("atomColors", atomColors);
+            map.put("atomColors", atomMap);
         }
         if(!Objects.equals(STEREO_COLOR_KNOWN, stereoColorKnown)){
             map.put("stereoColorKnown", stereoColorKnown.asHex());

--- a/src/test/java/gov/nih/ncats/molwitch/renderer/TestChemicalRendererJson.java
+++ b/src/test/java/gov/nih/ncats/molwitch/renderer/TestChemicalRendererJson.java
@@ -47,4 +47,23 @@ public class TestChemicalRendererJson {
         assertEquals(renderer.getBackgroundColorARGB(), sut.getBackgroundColorARGB());
         assertEquals(renderer.getBorderColorARGB(), sut.getBorderColorARGB());
     }
+    
+    @Test
+    public void testCopy() throws Exception{
+        ChemicalRenderer renderer = new ChemicalRenderer(RendererOptions.createUSPLike());
+        renderer.setShadowVisible(false);
+        renderer.setBackgroundColor(Color.red);
+
+        renderer.getOptions().getColorPalette().setAtomColor("S", new ARGBColor(45,45,67));
+        
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(renderer.getOptions());
+        
+        RendererOptions ropt= renderer.getOptions().copy();
+        String json2 = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(ropt);
+        
+        assertEquals(json,json2);
+        renderer = new ChemicalRenderer(ropt); //just checking if it can also instantiate        
+        assertNotNull(renderer);
+    }
 }


### PR DESCRIPTION
There was a bug in the old code where the serialized form of the atom color map was accidentally using the ARGBColor object instead of the hex value string. This led to copy functions breaking due to a typecast issue.